### PR TITLE
Enable and disable cap commands

### DIFF
--- a/.idea/artifacts/iop_blockchain_tool_jar.xml
+++ b/.idea/artifacts/iop_blockchain_tool_jar.xml
@@ -5,14 +5,14 @@
       <element id="module-output" name="iop-blockchain-tool" />
       <element id="extracted-dir" path="$APPLICATION_HOME_DIR$/lib/junit-4.12.jar" path-in-jar="/" />
       <element id="extracted-dir" path="$APPLICATION_HOME_DIR$/lib/hamcrest-core-1.3.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/madgag/spongycastle/core/1.54.0.0/core-1.54.0.0.jar" path-in-jar="/" />
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/google/guava/guava/18.0/guava-18.0.jar" path-in-jar="/" />
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/commons-cli/commons-cli/1.3.1/commons-cli-1.3.1.jar" path-in-jar="/" />
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/google/protobuf/protobuf-java/2.5.0/protobuf-java-2.5.0.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/madgag/spongycastle/core/1.54.0.0/core-1.54.0.0.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$USER_HOME$/IoP/coreClients/fermatj/core/target/fermatj-core-0.13.6.jar" path-in-jar="/" />
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/ch/qos/logback/logback-classic/0.9.30/logback-classic-0.9.30.jar" path-in-jar="/" />
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/ch/qos/logback/logback-core/0.9.30/logback-core-0.9.30.jar" path-in-jar="/" />
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/slf4j/slf4j-api/1.6.2/slf4j-api-1.6.2.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$USER_HOME$/AndroidStudioProjects/fermatOrg/fermatj/core/target/fermatj-core-0.13.6.jar" path-in-jar="/" />
     </root>
   </artifact>
 </component>

--- a/README.md
+++ b/README.md
@@ -13,12 +13,13 @@ $ java -jar iop-blockchain-tool/out/artifacts/iop_blockchain_tool_jar/iop-blockc
 ```
 usage: IoP-Blockchain-Tool [-a <arg>] [-d] [-h] [-n <arg>] [-P <arg>] [-p
        <arg>] [-v]
- -a,--action <arg>    ADD or REM a public key to the blockchain
+ -a,--action <arg>    ADD or REM a public key to the blockchain. ENABLE_CAP or DISABLE_CAP for miners.
  -d,--debug           Print debugging information. Disabled by default.
  -h,--help            Print this message
  -n,--network <arg>   MAIN, TEST, REGTEST networks. Default is MAIN
  -p,--private <arg>   Master private key
  -m,--MinerAddress <args>    One or up to 20 Miner addresses to add in the transaction.
+ -f, --factor <arg> The factor used to multiple the average block per miner to set the miner cap value. Default value is 2.
  -v,--version         Print the version information and exit
 
 ```
@@ -28,6 +29,8 @@ Mandatory arguments are:
 * -Action
  *ADD*:  adds a public key into the miner white list.
   *REM*:  removes a public key from the miner white list.
+  *ENABLE_CAP*: enables the miner cap on the blockchain. 
+  *DISABLE_CAP*: enables the miner cap on the blockchain.
   
   * -private: the **master private key** allowed to execute this transactions.
   
@@ -35,8 +38,16 @@ Mandatory arguments are:
   
 Default network is Mainnet. To switch, use the -network parameter. Example:
 
+Adds miner uZE6SzrtYnWwr2zUg7RsvQeHKSRjSH6hKJ on testnet network.
 ```
 iop-blockchain-tool.jar -a add -p validPrivateKey -m uZE6SzrtYnWwr2zUg7RsvQeHKSRjSH6hKJ -n Test
+```
+
+Enables the miner Cap in production and sets the factor to 3:
+
+```
+iop-blockchain-tool.jar  -p validPrivateKey -a enable_cap -f 3
+
 ```
 
 ## Program description

--- a/src/org/fermat/blockchain/FermatNetwork.java
+++ b/src/org/fermat/blockchain/FermatNetwork.java
@@ -85,6 +85,7 @@ public class FermatNetwork {
         if (NETWORK == RegTestParams.get())
         {
             peerGroup.setUseLocalhostPeerWhenPossible(true);
+            peerGroup.addAddress(new PeerAddress(new InetSocketAddress("127.0.0.1", 14820)));
             minBroadcastConnections = 1;
         } else {
             peerGroup.addPeerDiscovery(new DnsDiscovery(NETWORK));

--- a/src/org/fermat/blockchain/MinerWhiteListTransaction.java
+++ b/src/org/fermat/blockchain/MinerWhiteListTransaction.java
@@ -26,7 +26,7 @@ public class MinerWhiteListTransaction {
 
     //Action Enum
     public enum Action{
-        ADD , REM
+        ADD , REM, ENABLE_CAP, DISABLE_CAP
     }
 
     // constructor
@@ -34,7 +34,7 @@ public class MinerWhiteListTransaction {
         //preconditions check
         Preconditions.checkArgument(!privateKey.isEmpty());
         Preconditions.checkNotNull(action);
-        Preconditions.checkNotNull(minerAddresses);
+        //Preconditions.checkNotNull(minerAddresses);
 
         if (logger.getLevel() != Level.DEBUG)
             logger.setLevel(Level.OFF);
@@ -49,6 +49,10 @@ public class MinerWhiteListTransaction {
      * @return
      */
     private String getOP_Return (){
+        int factor = Main.factor;
+        if (factor == 0)
+            factor = 2;
+
         String data;
         switch (this.action){
             case ADD:
@@ -56,6 +60,12 @@ public class MinerWhiteListTransaction {
                 break;
             case REM:
                 data =  "rem";
+                break;
+            case ENABLE_CAP:
+                data = "enable_cap:" + factor; // we are including the factor of the cap
+                break;
+            case DISABLE_CAP:
+                data = "disable_cap";
                 break;
             default:
                 data =  "add";
@@ -103,10 +113,11 @@ public class MinerWhiteListTransaction {
         transaction.addOutput(op_returnOutput);
 
         // Add all the miners addresses into new outputs.
-        for (Address minerAddress : minerAddresses){
-            transaction.addOutput(Transaction.MIN_NONDUST_OUTPUT, minerAddress);
+        if (minerAddresses != null){
+            for (Address minerAddress : minerAddresses){
+                transaction.addOutput(Transaction.MIN_NONDUST_OUTPUT, minerAddress);
+            }
         }
-
         // we complete the transaction
         wallet.completeTx(sendRequest);
 

--- a/src/org/fermat/blockchain/TransactionSummary.java
+++ b/src/org/fermat/blockchain/TransactionSummary.java
@@ -46,10 +46,8 @@ public class TransactionSummary {
         try{
             StringBuilder output = new StringBuilder();
 
-            MinerWhiteListTransaction.Action action = MinerWhiteListTransaction.Action.valueOf(data.substring(0,3).toUpperCase());
-
             output.append("Action: ");
-            output.append(action.toString());
+            output.append(data);
             output.append(System.lineSeparator());
             output.append("Miner addresses: ");
             output.append(System.lineSeparator());


### PR DESCRIPTION
New commands:

* enable_cap : enables cap in the blockchain. may be used with -f (factor) parameter to specify the multiplying factor to calculate the minerCap. if not, factor defaults to 2.

* disable_cap: disables the miner cap flag in the blockchain.